### PR TITLE
Fixed null handling for findFirst/findUnique results in three routes

### DIFF
--- a/backend/src/services/course/course.routes.js
+++ b/backend/src/services/course/course.routes.js
@@ -65,6 +65,13 @@ module.exports = async function courseRoutes(fastify, options) {
         const res = await courseRepo.getCourseById(
           parseInt(request.params.course_id, 10)
         );
+        if (!res) {
+          return reply.code(404).send({
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Course not found',
+          });
+        }
         return res;
       } catch (error) {
         return mapAndReply(error, reply);
@@ -104,6 +111,13 @@ module.exports = async function courseRoutes(fastify, options) {
           parseInt(request.params.user_id, 10),
           parseInt(request.params.course_id, 10)
         );
+        if (!res) {
+          return reply.code(404).send({
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'User enrollment not found in this course',
+          });
+        }
         return mapUserAndEnrollmentToCourseUser(res.users, res);
       } catch (error) {
         return mapAndReply(error, reply);

--- a/backend/src/services/journal/journal.routes.js
+++ b/backend/src/services/journal/journal.routes.js
@@ -76,6 +76,13 @@ module.exports = async function journalRoutes(fastify, options) {
       try {
         const journal_id = request.params.journal_id;
         const res = await journalService.getJournalById(journal_id);
+        if (!res) {
+          return reply.code(404).send({
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Journal entry not found',
+          });
+        }
         return res;
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
- GET /courses/:course_id (course.routes.js): Returns 404 with "Course not found" if the course doesn't exist
- GET /courses/:course_id/users/:user_id (course.routes.js): Returns 404 with "User enrollment not found in this course" if enrollment doesn't exist
- GET /journals/:journal_id (journal.routes.js): Returns 404 with "Journal entry not found" if the journal doesn't exist